### PR TITLE
Always return a default SeoMetaItem

### DIFF
--- a/src/Traits/SeoMetaTrait.php
+++ b/src/Traits/SeoMetaTrait.php
@@ -14,7 +14,9 @@ trait SeoMetaTrait
      */
     public function seo_meta()
     {
-        return $this->morphOne(SeoMetaItem::class, 'seo_metaable');
+        return $this->morphOne(SeoMetaItem::class, 'seo_metaable')->withDefault(
+            new SeoMetaItem()
+        );
     }
 
     /**


### PR DESCRIPTION
In my opinion, the SEO data acts not so much as "related data", but as attributes of the model.  
That's why I think it's a good idea to always return a `SeoMetaItem` model, to make it safe to assume all SEO properties are there.

I'm motivated by the fact that I'm working on a headless implementation of Nova CMS, creating a JSON API to publish its content to a React application. 
It's a bit more user-friendly on the front-end to have the API contain `page.seo.description = null` instead of `page.seo = null`.

I realize this is opinionated, so let me know if you're willing to merge this, or whether you'd like to see changes. 🙂 
Thanks in advance!