### PR TITLE
Nova Page support

### DIFF
--- a/src/SeoMeta.php
+++ b/src/SeoMeta.php
@@ -59,6 +59,10 @@ class SeoMeta extends Field
      */
     public function resolve($resource, $attribute = null)
     {
+        if ($resource instanceof \Whitecube\NovaPage\Pages\Template) {
+            $resource = $resource->getOriginal();
+        }
+
         parent::resolve($resource, $attribute);
 
         $meta = [
@@ -136,6 +140,10 @@ class SeoMeta extends Field
                                                 $model,
                                                 $attribute)
     {
+        if ($model instanceof \Whitecube\NovaPage\Pages\Template) {
+            $model = $model->getOriginal();
+        }
+
         $has_change = false;
         $relationship = $model->{$attribute} ?? new SeoMetaItem;
 


### PR DESCRIPTION
I'm trying to use this package with Nova Page (https://github.com/whitecube/nova-page).

Nova Page uses templates on top of the underlying Page model. Because the SEO data needs to be saved against a relationship of this underlying model, I've added a check in the resolve and fill methods which will update the resource to that of the underlying model rather than the template.

Note that `instanceof` does not throw errors if the class it's checking against doesn't exist, so this shouldn't cause any problems for people using this package without Nova Page installed.